### PR TITLE
fix tenant relation sql parameters

### DIFF
--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/CustomerSubscriptionRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/CustomerSubscriptionRepository.g.cs
@@ -74,75 +74,74 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 		}
 
 		*/
-		/*
 		public void InsertMany(IEnumerable<TestRepositoryGeneration.DataObjects.BaseRepositories.CustomerSubscription> customerSubscriptionList)
 		{
-		if(customerSubscriptionList==null) throw new ArgumentException(nameof(customerSubscriptionList));
+			if (customerSubscriptionList == null) throw new ArgumentException(nameof(customerSubscriptionList));
 
-		if(!customerSubscriptionList.Any()) return;
+			if (!customerSubscriptionList.Any()) return;
 
-		var query = new System.Text.StringBuilder();
-		var counter = 0;
-		var parameters = new Dictionary<string, object> ();
-		foreach (var customerSubscription in customerSubscriptionList)
-		{
-		if (parameters.Count + 9 > MaxRepositoryParams)
-		{
-		DataAccessService.Execute(query.ToString(), parameters);
-		query.Clear();
-		counter = 0;
-		parameters.Clear();
-		}
-		parameters.Add($"CustomerId{counter}", customerSubscription.CustomerId);
-		parameters.Add($"CustomerNotificationsType{counter}", customerSubscription.CustomerNotificationsType);
-		parameters.Add($"Email{counter}", customerSubscription.Email);
-		parameters.Add($"SMS{counter}", customerSubscription.SMS);
-		parameters.Add($"Push{counter}", customerSubscription.Push);
-		parameters.Add($"IsCustomizable{counter}", customerSubscription.IsCustomizable);
-		parameters.Add($"ResendPeriod{counter}", customerSubscription.ResendPeriod);
-		parameters.Add($"IsDeleted{counter}", customerSubscription.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
-		query.AppendFormat(InsertManyQuery, counter);
-		counter++;
-		}
-		DataAccessService.Execute(query.ToString(), parameters);
+			var query = new System.Text.StringBuilder();
+			var counter = 0;
+			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+			foreach (var customerSubscription in customerSubscriptionList)
+			{
+				if (parameters.Count + 9 > MaxRepositoryParams)
+				{
+					DataAccessService.Execute(query.ToString(), parameters);
+					query.Clear();
+					counter = 0;
+					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+				}
+				parameters.Add($"CustomerId{counter}", customerSubscription.CustomerId);
+				parameters.Add($"CustomerNotificationsType{counter}", customerSubscription.CustomerNotificationsType);
+				parameters.Add($"Email{counter}", customerSubscription.Email);
+				parameters.Add($"SMS{counter}", customerSubscription.SMS);
+				parameters.Add($"Push{counter}", customerSubscription.Push);
+				parameters.Add($"IsCustomizable{counter}", customerSubscription.IsCustomizable);
+				parameters.Add($"ResendPeriod{counter}", customerSubscription.ResendPeriod);
+				parameters.Add($"IsDeleted{counter}", customerSubscription.IsDeleted);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
+			}
+			DataAccessService.Execute(query.ToString(), parameters);
 		}
 
 		public async Task InsertManyAsync(IEnumerable<TestRepositoryGeneration.DataObjects.BaseRepositories.CustomerSubscription> customerSubscriptionList)
 		{
-		if(customerSubscriptionList==null) throw new ArgumentException(nameof(customerSubscriptionList));
+			if (customerSubscriptionList == null) throw new ArgumentException(nameof(customerSubscriptionList));
 
-		if(!customerSubscriptionList.Any()) return;
+			if (!customerSubscriptionList.Any()) return;
 
-		var query = new System.Text.StringBuilder();
-		var counter = 0;
-		var parameters = new Dictionary<string, object>();
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
-		foreach (var customerSubscription in customerSubscriptionList)
-		{
-		if (parameters.Count + 9 > MaxRepositoryParams)
-		{
-		await DataAccessService.ExecuteAsync(query.ToString(), parameters);
-		query.Clear();
-		counter = 0;
-		parameters.Clear();
-		}
-		parameters.Add($"CustomerId{counter}", customerSubscription.CustomerId);
-		parameters.Add($"CustomerNotificationsType{counter}", customerSubscription.CustomerNotificationsType);
-		parameters.Add($"Email{counter}", customerSubscription.Email);
-		parameters.Add($"SMS{counter}", customerSubscription.SMS);
-		parameters.Add($"Push{counter}", customerSubscription.Push);
-		parameters.Add($"IsCustomizable{counter}", customerSubscription.IsCustomizable);
-		parameters.Add($"ResendPeriod{counter}", customerSubscription.ResendPeriod);
-		parameters.Add($"IsDeleted{counter}", customerSubscription.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
-		query.AppendFormat(InsertManyQuery, counter);
-		counter++;
-		}
-		await DataAccessService.ExecuteAsync(query.ToString(), parameters);
+			var query = new System.Text.StringBuilder();
+			var counter = 0;
+			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+			foreach (var customerSubscription in customerSubscriptionList)
+			{
+				if (parameters.Count + 9 > MaxRepositoryParams)
+				{
+					await DataAccessService.ExecuteAsync(query.ToString(), parameters);
+					query.Clear();
+					counter = 0;
+					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+				}
+				parameters.Add($"CustomerId{counter}", customerSubscription.CustomerId);
+				parameters.Add($"CustomerNotificationsType{counter}", customerSubscription.CustomerNotificationsType);
+				parameters.Add($"Email{counter}", customerSubscription.Email);
+				parameters.Add($"SMS{counter}", customerSubscription.SMS);
+				parameters.Add($"Push{counter}", customerSubscription.Push);
+				parameters.Add($"IsCustomizable{counter}", customerSubscription.IsCustomizable);
+				parameters.Add($"ResendPeriod{counter}", customerSubscription.ResendPeriod);
+				parameters.Add($"IsDeleted{counter}", customerSubscription.IsDeleted);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
+			}
+			await DataAccessService.ExecuteAsync(query.ToString(), parameters);
 		}
 
-		*/
 		/*
 		public void UpdateByCustomerIdAndCustomerNotificationsType(TestRepositoryGeneration.DataObjects.BaseRepositories.CustomerSubscription customerSubscription)
 		{

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/ElectronicCouponRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/ElectronicCouponRepository.g.cs
@@ -102,6 +102,7 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 			var query = new System.Text.StringBuilder();
 			var counter = 0;
 			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 			foreach (var electronicCoupon in electronicCouponList)
 			{
 				if (parameters.Count + 12 > MaxRepositoryParams)
@@ -110,6 +111,7 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"Id{counter}", electronicCoupon.Id);
 				parameters.Add($"Name{counter}", electronicCoupon.Name);
@@ -122,7 +124,6 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 				parameters.Add($"Priority{counter}", electronicCoupon.Priority);
 				parameters.Add($"MaxTimesPerCustomer{counter}", electronicCoupon.MaxTimesPerCustomer);
 				parameters.Add($"IsActive{counter}", electronicCoupon.IsActive);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				query.AppendFormat(InsertManyQuery, counter);
 				counter++;
 			}
@@ -147,6 +148,7 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"Id{counter}", electronicCoupon.Id);
 				parameters.Add($"Name{counter}", electronicCoupon.Name);
@@ -159,7 +161,6 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 				parameters.Add($"Priority{counter}", electronicCoupon.Priority);
 				parameters.Add($"MaxTimesPerCustomer{counter}", electronicCoupon.MaxTimesPerCustomer);
 				parameters.Add($"IsActive{counter}", electronicCoupon.IsActive);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				query.AppendFormat(InsertManyQuery, counter);
 				counter++;
 			}

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/ElectronicCouponsTypedRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/ElectronicCouponsTypedRepository.g.cs
@@ -95,87 +95,86 @@ namespace TestRepositoryGeneration.CustomRepositories.BaseRepositories
 		}
 
 		*/
-		/*
 		public void InsertMany(IEnumerable<TestRepositoryGeneration.DataObjects.BaseRepositories.ElectronicCouponsTyped> electronicCouponsTypedList)
 		{
-		if(electronicCouponsTypedList==null) throw new ArgumentException(nameof(electronicCouponsTypedList));
+			if (electronicCouponsTypedList == null) throw new ArgumentException(nameof(electronicCouponsTypedList));
 
-		if(!electronicCouponsTypedList.Any()) return;
+			if (!electronicCouponsTypedList.Any()) return;
 
-		var query = new System.Text.StringBuilder();
-		var counter = 0;
-		var parameters = new Dictionary<string, object> ();
-		foreach (var electronicCouponsTyped in electronicCouponsTypedList)
-		{
-		if (parameters.Count + 4 > MaxRepositoryParams)
-		{
-		DataAccessService.Execute(query.ToString(), parameters);
-		query.Clear();
-		counter = 0;
-		parameters.Clear();
-		}
-		parameters.Add($"ElectronicCouponsId{counter}", electronicCouponsTyped.ElectronicCouponsId);
-		parameters.Add($"ElectronicCouponsPresetId{counter}", electronicCouponsTyped.ElectronicCouponsPresetId);
-		parameters.Add($"IsPromotionalCampaign{counter}", electronicCouponsTyped.IsPromotionalCampaign);
-		parameters.Add($"Id{counter}", electronicCouponsTyped.Id);
-		parameters.Add($"Name{counter}", electronicCouponsTyped.Name);
-		parameters.Add($"PrintText{counter}", electronicCouponsTyped.PrintText);
-		parameters.Add($"ImageId{counter}", electronicCouponsTyped.ImageId);
-		parameters.Add($"ValidFrom{counter}", electronicCouponsTyped.ValidFrom);
-		parameters.Add($"ValidTo{counter}", electronicCouponsTyped.ValidTo);
-		parameters.Add($"IsDeleted{counter}", electronicCouponsTyped.IsDeleted);
-		parameters.Add($"LimitPerOrder{counter}", electronicCouponsTyped.LimitPerOrder);
-		parameters.Add($"Priority{counter}", electronicCouponsTyped.Priority);
-		parameters.Add($"MaxTimesPerCustomer{counter}", electronicCouponsTyped.MaxTimesPerCustomer);
-		parameters.Add($"IsActive{counter}", electronicCouponsTyped.IsActive);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
-		query.AppendFormat(InsertManyQuery, counter);
-		counter++;
-		}
-		DataAccessService.Execute(query.ToString(), parameters);
+			var query = new System.Text.StringBuilder();
+			var counter = 0;
+			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+			foreach (var electronicCouponsTyped in electronicCouponsTypedList)
+			{
+				if (parameters.Count + 4 > MaxRepositoryParams)
+				{
+					DataAccessService.Execute(query.ToString(), parameters);
+					query.Clear();
+					counter = 0;
+					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+				}
+				parameters.Add($"ElectronicCouponsId{counter}", electronicCouponsTyped.ElectronicCouponsId);
+				parameters.Add($"ElectronicCouponsPresetId{counter}", electronicCouponsTyped.ElectronicCouponsPresetId);
+				parameters.Add($"IsPromotionalCampaign{counter}", electronicCouponsTyped.IsPromotionalCampaign);
+				parameters.Add($"Id{counter}", electronicCouponsTyped.Id);
+				parameters.Add($"Name{counter}", electronicCouponsTyped.Name);
+				parameters.Add($"PrintText{counter}", electronicCouponsTyped.PrintText);
+				parameters.Add($"ImageId{counter}", electronicCouponsTyped.ImageId);
+				parameters.Add($"ValidFrom{counter}", electronicCouponsTyped.ValidFrom);
+				parameters.Add($"ValidTo{counter}", electronicCouponsTyped.ValidTo);
+				parameters.Add($"IsDeleted{counter}", electronicCouponsTyped.IsDeleted);
+				parameters.Add($"LimitPerOrder{counter}", electronicCouponsTyped.LimitPerOrder);
+				parameters.Add($"Priority{counter}", electronicCouponsTyped.Priority);
+				parameters.Add($"MaxTimesPerCustomer{counter}", electronicCouponsTyped.MaxTimesPerCustomer);
+				parameters.Add($"IsActive{counter}", electronicCouponsTyped.IsActive);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
+			}
+			DataAccessService.Execute(query.ToString(), parameters);
 		}
 
 		public async Task InsertManyAsync(IEnumerable<TestRepositoryGeneration.DataObjects.BaseRepositories.ElectronicCouponsTyped> electronicCouponsTypedList)
 		{
-		if(electronicCouponsTypedList==null) throw new ArgumentException(nameof(electronicCouponsTypedList));
+			if (electronicCouponsTypedList == null) throw new ArgumentException(nameof(electronicCouponsTypedList));
 
-		if(!electronicCouponsTypedList.Any()) return;
+			if (!electronicCouponsTypedList.Any()) return;
 
-		var query = new System.Text.StringBuilder();
-		var counter = 0;
-		var parameters = new Dictionary<string, object>();
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
-		foreach (var electronicCouponsTyped in electronicCouponsTypedList)
-		{
-		if (parameters.Count + 4 > MaxRepositoryParams)
-		{
-		await DataAccessService.ExecuteAsync(query.ToString(), parameters);
-		query.Clear();
-		counter = 0;
-		parameters.Clear();
-		}
-		parameters.Add($"ElectronicCouponsId{counter}", electronicCouponsTyped.ElectronicCouponsId);
-		parameters.Add($"ElectronicCouponsPresetId{counter}", electronicCouponsTyped.ElectronicCouponsPresetId);
-		parameters.Add($"IsPromotionalCampaign{counter}", electronicCouponsTyped.IsPromotionalCampaign);
-		parameters.Add($"Id{counter}", electronicCouponsTyped.Id);
-		parameters.Add($"Name{counter}", electronicCouponsTyped.Name);
-		parameters.Add($"PrintText{counter}", electronicCouponsTyped.PrintText);
-		parameters.Add($"ImageId{counter}", electronicCouponsTyped.ImageId);
-		parameters.Add($"ValidFrom{counter}", electronicCouponsTyped.ValidFrom);
-		parameters.Add($"ValidTo{counter}", electronicCouponsTyped.ValidTo);
-		parameters.Add($"IsDeleted{counter}", electronicCouponsTyped.IsDeleted);
-		parameters.Add($"LimitPerOrder{counter}", electronicCouponsTyped.LimitPerOrder);
-		parameters.Add($"Priority{counter}", electronicCouponsTyped.Priority);
-		parameters.Add($"MaxTimesPerCustomer{counter}", electronicCouponsTyped.MaxTimesPerCustomer);
-		parameters.Add($"IsActive{counter}", electronicCouponsTyped.IsActive);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
-		query.AppendFormat(InsertManyQuery, counter);
-		counter++;
-		}
-		await DataAccessService.ExecuteAsync(query.ToString(), parameters);
+			var query = new System.Text.StringBuilder();
+			var counter = 0;
+			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+			foreach (var electronicCouponsTyped in electronicCouponsTypedList)
+			{
+				if (parameters.Count + 4 > MaxRepositoryParams)
+				{
+					await DataAccessService.ExecuteAsync(query.ToString(), parameters);
+					query.Clear();
+					counter = 0;
+					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+				}
+				parameters.Add($"ElectronicCouponsId{counter}", electronicCouponsTyped.ElectronicCouponsId);
+				parameters.Add($"ElectronicCouponsPresetId{counter}", electronicCouponsTyped.ElectronicCouponsPresetId);
+				parameters.Add($"IsPromotionalCampaign{counter}", electronicCouponsTyped.IsPromotionalCampaign);
+				parameters.Add($"Id{counter}", electronicCouponsTyped.Id);
+				parameters.Add($"Name{counter}", electronicCouponsTyped.Name);
+				parameters.Add($"PrintText{counter}", electronicCouponsTyped.PrintText);
+				parameters.Add($"ImageId{counter}", electronicCouponsTyped.ImageId);
+				parameters.Add($"ValidFrom{counter}", electronicCouponsTyped.ValidFrom);
+				parameters.Add($"ValidTo{counter}", electronicCouponsTyped.ValidTo);
+				parameters.Add($"IsDeleted{counter}", electronicCouponsTyped.IsDeleted);
+				parameters.Add($"LimitPerOrder{counter}", electronicCouponsTyped.LimitPerOrder);
+				parameters.Add($"Priority{counter}", electronicCouponsTyped.Priority);
+				parameters.Add($"MaxTimesPerCustomer{counter}", electronicCouponsTyped.MaxTimesPerCustomer);
+				parameters.Add($"IsActive{counter}", electronicCouponsTyped.IsActive);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
+			}
+			await DataAccessService.ExecuteAsync(query.ToString(), parameters);
 		}
 
-		*/
 		/*
 		public void UpdateByElectronicCouponsId(TestRepositoryGeneration.DataObjects.BaseRepositories.ElectronicCouponsTyped electronicCouponsTyped)
 		{

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/EmployeesInRolesScheduleRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/EmployeesInRolesScheduleRepository.g.cs
@@ -102,6 +102,7 @@ namespace TestRepositoryGeneration
 		var query = new System.Text.StringBuilder();
 		var counter = 0;
 		var parameters = new Dictionary<string, object> ();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		foreach (var employeesInRolesSchedule in employeesInRolesScheduleList)
 		{
 		if (parameters.Count + 9 > MaxRepositoryParams)
@@ -110,6 +111,7 @@ namespace TestRepositoryGeneration
 		query.Clear();
 		counter = 0;
 		parameters.Clear();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		}
 		parameters.Add($"ScheduleId{counter}", employeesInRolesSchedule.ScheduleId);
 		parameters.Add($"RoleId{counter}", employeesInRolesSchedule.RoleId);
@@ -119,7 +121,6 @@ namespace TestRepositoryGeneration
 		parameters.Add($"Start{counter}", employeesInRolesSchedule.Start);
 		parameters.Add($"End{counter}", employeesInRolesSchedule.End);
 		parameters.Add($"IsDeleted{counter}", employeesInRolesSchedule.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		query.AppendFormat(InsertManyQuery, counter);
 		counter++;
 		}
@@ -144,6 +145,7 @@ namespace TestRepositoryGeneration
 		query.Clear();
 		counter = 0;
 		parameters.Clear();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		}
 		parameters.Add($"ScheduleId{counter}", employeesInRolesSchedule.ScheduleId);
 		parameters.Add($"RoleId{counter}", employeesInRolesSchedule.RoleId);
@@ -153,7 +155,6 @@ namespace TestRepositoryGeneration
 		parameters.Add($"Start{counter}", employeesInRolesSchedule.Start);
 		parameters.Add($"End{counter}", employeesInRolesSchedule.End);
 		parameters.Add($"IsDeleted{counter}", employeesInRolesSchedule.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		query.AppendFormat(InsertManyQuery, counter);
 		counter++;
 		}

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItemCacheRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItemCacheRepository.g.cs
@@ -150,6 +150,7 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 			var query = new System.Text.StringBuilder();
 			var counter = 0;
 			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 			foreach (var menuItem in menuItemList)
 			{
 				if (parameters.Count + 4 > MaxRepositoryParams)
@@ -158,6 +159,7 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"MenuItemId{counter}", menuItem.MenuItemId);
 				parameters.Add($"MenuItemVersionId{counter}", menuItem.MenuItemVersionId);
@@ -168,7 +170,6 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 				parameters.Add($"Modified{counter}", menuItem.Modified);
 				parameters.Add($"ModifiedBy{counter}", menuItem.ModifiedBy);
 				parameters.Add($"CategoryId{counter}", menuItem.CategoryId);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				query.AppendFormat(InsertManyQuery, counter);
 				counter++;
 			}
@@ -193,6 +194,7 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"MenuItemId{counter}", menuItem.MenuItemId);
 				parameters.Add($"MenuItemVersionId{counter}", menuItem.MenuItemVersionId);
@@ -203,7 +205,6 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 				parameters.Add($"Modified{counter}", menuItem.Modified);
 				parameters.Add($"ModifiedBy{counter}", menuItem.ModifiedBy);
 				parameters.Add($"CategoryId{counter}", menuItem.CategoryId);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				query.AppendFormat(InsertManyQuery, counter);
 				counter++;
 			}

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItemVersionRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItemVersionRepository.g.cs
@@ -57,6 +57,7 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@MenuCategoryId{0},@TenantId{0})";
 			var query = new System.Text.StringBuilder();
 			var counter = 0;
 			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 			foreach (var menuItem in menuItemList)
 			{
 				if (parameters.Count + 4 > MaxRepositoryParams)
@@ -65,8 +66,7 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@MenuCategoryId{0},@TenantId{0})";
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
-					query.AppendFormat(InsertManyQuery, counter);
-					counter++;
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"MenuItemId{counter}", menuItem.MenuItemId);
 				parameters.Add($"MenuItemVersionId{counter}", menuItem.MenuItemVersionId);
@@ -77,7 +77,8 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@MenuCategoryId{0},@TenantId{0})";
 				parameters.Add($"Modified{counter}", menuItem.Modified);
 				parameters.Add($"ModifiedBy{counter}", menuItem.ModifiedBy);
 				parameters.Add($"CategoryId{counter}", menuItem.CategoryId);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
 			}
 			DataAccessService.Execute(query.ToString(), parameters);
 		}
@@ -91,6 +92,7 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@MenuCategoryId{0},@TenantId{0})";
 			var query = new System.Text.StringBuilder();
 			var counter = 0;
 			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 			foreach (var menuItem in menuItemList)
 			{
 				if (parameters.Count + 4 > MaxRepositoryParams)
@@ -99,6 +101,7 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@MenuCategoryId{0},@TenantId{0})";
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"MenuItemId{counter}", menuItem.MenuItemId);
 				parameters.Add($"MenuItemVersionId{counter}", menuItem.MenuItemVersionId);
@@ -109,7 +112,6 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@MenuCategoryId{0},@TenantId{0})";
 				parameters.Add($"Modified{counter}", menuItem.Modified);
 				parameters.Add($"ModifiedBy{counter}", menuItem.ModifiedBy);
 				parameters.Add($"CategoryId{counter}", menuItem.CategoryId);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				query.AppendFormat(InsertManyQuery, counter);
 				counter++;
 			}

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItems2TaxesCacheRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItems2TaxesCacheRepository.g.cs
@@ -112,6 +112,7 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 			await DataAccessService.InsertObjectAsync(menuItems2Taxes, InsertQuery);
 		}
 
+		/*
 		public void InsertMany(IEnumerable<TestRepositoryGeneration.DataObjects.VersionsRepositories.MenuItems2Taxes> menuItems2TaxesList)
 		{
 		if(menuItems2TaxesList==null) throw new ArgumentException(nameof(menuItems2TaxesList));
@@ -174,6 +175,7 @@ namespace TestRepositoryGeneration.CustomRepositories.VersionsRepositories
 		await DataAccessService.ExecuteAsync(query.ToString(), parameters);
 		}
 
+		*/
 		public void UpdateByMenuItemId(TestRepositoryGeneration.DataObjects.VersionsRepositories.MenuItems2Taxes menuItems2Taxes)
 		{
 			var sql = UpdateQueryBy + WhereQueryByMenuItemId;

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItems2TaxesVersionRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/MenuItems2TaxesVersionRepository.g.cs
@@ -49,8 +49,6 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@Modified{0},@ModifiedBy{0},@TaxId{
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
-					query.AppendFormat(InsertManyQuery, counter);
-					counter++;
 				}
 				parameters.Add($"MenuItemId{counter}", menuItems2Taxes.MenuItemId);
 				parameters.Add($"MenuItemVersionId{counter}", menuItems2Taxes.MenuItemVersionId);
@@ -59,6 +57,8 @@ VALUES (@MenuItemId{0},@MenuItemVersionId{0},@Modified{0},@ModifiedBy{0},@TaxId{
 				parameters.Add($"TaxId{counter}", menuItems2Taxes.TaxId);
 				parameters.Add($"TaxVersionId{counter}", menuItems2Taxes.TaxVersionId);
 				parameters.Add($"IsDeleted{counter}", menuItems2Taxes.IsDeleted);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
 			}
 			DataAccessService.Execute(query.ToString(), parameters);
 		}

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/TaxCacheRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/TaxCacheRepository.g.cs
@@ -127,6 +127,7 @@ namespace TestRepositoryGeneration
 		var query = new System.Text.StringBuilder();
 		var counter = 0;
 		var parameters = new Dictionary<string, object> ();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		foreach (var tax in taxList)
 		{
 		if (parameters.Count + 7 > MaxRepositoryParams)
@@ -135,6 +136,7 @@ namespace TestRepositoryGeneration
 		query.Clear();
 		counter = 0;
 		parameters.Clear();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		}
 		parameters.Add($"TaxId{counter}", tax.TaxId);
 		parameters.Add($"TaxVersionId{counter}", tax.TaxVersionId);
@@ -142,7 +144,6 @@ namespace TestRepositoryGeneration
 		parameters.Add($"Modified{counter}", tax.Modified);
 		parameters.Add($"ModifiedBy{counter}", tax.ModifiedBy);
 		parameters.Add($"IsDeleted{counter}", tax.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		query.AppendFormat(InsertManyQuery, counter);
 		counter++;
 		}
@@ -167,6 +168,7 @@ namespace TestRepositoryGeneration
 		query.Clear();
 		counter = 0;
 		parameters.Clear();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		}
 		parameters.Add($"TaxId{counter}", tax.TaxId);
 		parameters.Add($"TaxVersionId{counter}", tax.TaxVersionId);
@@ -174,7 +176,6 @@ namespace TestRepositoryGeneration
 		parameters.Add($"Modified{counter}", tax.Modified);
 		parameters.Add($"ModifiedBy{counter}", tax.ModifiedBy);
 		parameters.Add($"IsDeleted{counter}", tax.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		query.AppendFormat(InsertManyQuery, counter);
 		counter++;
 		}

--- a/Sandbox/TestRepositoryGeneration/GeneratedRepositories/TaxVersionRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/GeneratedRepositories/TaxVersionRepository.g.cs
@@ -50,6 +50,7 @@ VALUES (@TaxId{0},@TaxVersionId{0},@Name{0},@Modified{0},@ModifiedBy{0},@IsDelet
 			var query = new System.Text.StringBuilder();
 			var counter = 0;
 			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 			foreach (var tax in taxList)
 			{
 				if (parameters.Count + 7 > MaxRepositoryParams)
@@ -58,8 +59,7 @@ VALUES (@TaxId{0},@TaxVersionId{0},@Name{0},@Modified{0},@ModifiedBy{0},@IsDelet
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
-					query.AppendFormat(InsertManyQuery, counter);
-					counter++;
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"TaxId{counter}", tax.TaxId);
 				parameters.Add($"TaxVersionId{counter}", tax.TaxVersionId);
@@ -67,7 +67,8 @@ VALUES (@TaxId{0},@TaxVersionId{0},@Name{0},@Modified{0},@ModifiedBy{0},@IsDelet
 				parameters.Add($"Modified{counter}", tax.Modified);
 				parameters.Add($"ModifiedBy{counter}", tax.ModifiedBy);
 				parameters.Add($"IsDeleted{counter}", tax.IsDeleted);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
+				query.AppendFormat(InsertManyQuery, counter);
+				counter++;
 			}
 			DataAccessService.Execute(query.ToString(), parameters);
 		}
@@ -81,6 +82,7 @@ VALUES (@TaxId{0},@TaxVersionId{0},@Name{0},@Modified{0},@ModifiedBy{0},@IsDelet
 			var query = new System.Text.StringBuilder();
 			var counter = 0;
 			var parameters = new Dictionary<string, object>();
+			parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 			foreach (var tax in taxList)
 			{
 				if (parameters.Count + 7 > MaxRepositoryParams)
@@ -89,6 +91,7 @@ VALUES (@TaxId{0},@TaxVersionId{0},@Name{0},@Modified{0},@ModifiedBy{0},@IsDelet
 					query.Clear();
 					counter = 0;
 					parameters.Clear();
+					parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				}
 				parameters.Add($"TaxId{counter}", tax.TaxId);
 				parameters.Add($"TaxVersionId{counter}", tax.TaxVersionId);
@@ -96,7 +99,6 @@ VALUES (@TaxId{0},@TaxVersionId{0},@Name{0},@Modified{0},@ModifiedBy{0},@IsDelet
 				parameters.Add($"Modified{counter}", tax.Modified);
 				parameters.Add($"ModifiedBy{counter}", tax.ModifiedBy);
 				parameters.Add($"IsDeleted{counter}", tax.IsDeleted);
-				parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 				query.AppendFormat(InsertManyQuery, counter);
 				counter++;
 			}

--- a/Sandbox/TestRepositoryGeneration/PostgresRepositories/CustomerSubscriptionArchiveRepository.g.cs
+++ b/Sandbox/TestRepositoryGeneration/PostgresRepositories/CustomerSubscriptionArchiveRepository.g.cs
@@ -84,6 +84,7 @@ namespace TestRepositoryGeneration
 		var query = new System.Text.StringBuilder();
 		var counter = 0;
 		var parameters = new Dictionary<string, object> ();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		foreach (var customerSubscription in customerSubscriptionList)
 		{
 		if (parameters.Count + 9 > MaxRepositoryParams)
@@ -92,6 +93,7 @@ namespace TestRepositoryGeneration
 		query.Clear();
 		counter = 0;
 		parameters.Clear();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		}
 		parameters.Add($"CustomerId{counter}", customerSubscription.CustomerId);
 		parameters.Add($"CustomerNotificationsType{counter}", customerSubscription.CustomerNotificationsType);
@@ -101,7 +103,6 @@ namespace TestRepositoryGeneration
 		parameters.Add($"IsCustomizable{counter}", customerSubscription.IsCustomizable);
 		parameters.Add($"ResendPeriod{counter}", customerSubscription.ResendPeriod);
 		parameters.Add($"IsDeleted{counter}", customerSubscription.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		query.AppendFormat(InsertManyQuery, counter);
 		counter++;
 		}
@@ -126,6 +127,7 @@ namespace TestRepositoryGeneration
 		query.Clear();
 		counter = 0;
 		parameters.Clear();
+		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		}
 		parameters.Add($"CustomerId{counter}", customerSubscription.CustomerId);
 		parameters.Add($"CustomerNotificationsType{counter}", customerSubscription.CustomerNotificationsType);
@@ -135,7 +137,6 @@ namespace TestRepositoryGeneration
 		parameters.Add($"IsCustomizable{counter}", customerSubscription.IsCustomizable);
 		parameters.Add($"ResendPeriod{counter}", customerSubscription.ResendPeriod);
 		parameters.Add($"IsDeleted{counter}", customerSubscription.IsDeleted);
-		parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);
 		query.AppendFormat(InsertManyQuery, counter);
 		counter++;
 		}

--- a/Sandbox/TestRepositoryGeneration/RepositoryInterfaces/ICustomerSubscriptionRepository.cs
+++ b/Sandbox/TestRepositoryGeneration/RepositoryInterfaces/ICustomerSubscriptionRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using TestRepositoryGeneration.DataObjects.BaseRepositories;
 
 namespace TestRepositoryGeneration.RepositoryInterfaces
@@ -6,5 +7,7 @@ namespace TestRepositoryGeneration.RepositoryInterfaces
     public interface ICustomerSubscriptionRepository : IRepository<CustomerSubscription>
     {
         Task<CustomerSubscription> GetByCustomerIdAndCustomerNotificationsTypeAsync(string customerId, int customerNotificationsType);
+
+        Task InsertManyAsync(IEnumerable<CustomerSubscription> customerSubscriptionList);
     }
 }

--- a/Sandbox/TestRepositoryGeneration/RepositoryInterfaces/IElectronicCouponsTypedRepository.cs
+++ b/Sandbox/TestRepositoryGeneration/RepositoryInterfaces/IElectronicCouponsTypedRepository.cs
@@ -14,6 +14,8 @@ namespace TestRepositoryGeneration.RepositoryInterfaces
 
         Task<int> InsertAsync(ElectronicCouponsTyped electronicCouponsTyped);
 
+        Task InsertManyAsync(IEnumerable<ElectronicCouponsTyped> electronicCouponsTypedList);
+        
         Task UpdateByElectronicCouponsIdAsync(ElectronicCouponsTyped electronicCouponsTyped);
 
         Task RemoveByElectronicCouponsIdAsync(int id);

--- a/WCF-Generator/RepositoriesGeneration/Core/RepositoryCodeGenerator.cs
+++ b/WCF-Generator/RepositoriesGeneration/Core/RepositoryCodeGenerator.cs
@@ -466,7 +466,12 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("var query = new System.Text.StringBuilder();");
             sb.AppendLine("var counter = 0;");
             sb.AppendLine($"var parameters = new Dictionary<string, object> ();");
-            
+
+            if (RepositoryInfo.IsTenantRelated)
+            {
+                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
+            }
+
             sb.AppendLine($"foreach (var {elementName} in {parameterName})");
             sb.AppendLine("{");
 
@@ -476,18 +481,19 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("query.Clear();");
             sb.AppendLine("counter = 0;");
             sb.AppendLine("parameters.Clear();");
-            sb.AppendLine("}");
-
-            foreach (var column in columns)
-            {
-                sb.AppendLine($"parameters.Add($\"{column}{{counter}}\", {elementName}.{column});");
-            }
 
             if (RepositoryInfo.IsTenantRelated)
             {
                 sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
             }
 
+            sb.AppendLine("}");
+
+            foreach (var column in columns)
+            {
+                sb.AppendLine($"parameters.Add($\"{column}{{counter}}\", {elementName}.{column});");
+            }
+            
             sb.AppendLine($"query.AppendFormat({queryName}, counter);");
             sb.AppendLine("counter++;");
             
@@ -521,18 +527,19 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("query.Clear();");
             sb.AppendLine("counter = 0;");
             sb.AppendLine("parameters.Clear();");
-            sb.AppendLine("}");
-
-            foreach (var column in columns)
-            {
-                 sb.AppendLine($"parameters.Add($\"{column}{{counter}}\", {elementName}.{column});");
-            }
 
             if (RepositoryInfo.IsTenantRelated)
             {
                 sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
             }
 
+            sb.AppendLine("}");
+
+            foreach (var column in columns)
+            {
+                 sb.AppendLine($"parameters.Add($\"{column}{{counter}}\", {elementName}.{column});");
+            }
+            
             sb.AppendLine($"query.AppendFormat({queryName}, counter);");
             sb.AppendLine("counter++;");
           

--- a/WCF-Generator/RepositoriesGeneration/Core/VersionsRepositoryCodeGenerator.cs
+++ b/WCF-Generator/RepositoriesGeneration/Core/VersionsRepositoryCodeGenerator.cs
@@ -197,6 +197,12 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("var query = new System.Text.StringBuilder();");
             sb.AppendLine("var counter = 0;");
             sb.AppendLine($"var parameters = new Dictionary<string, object> ();");
+
+            if (RepositoryInfo.IsTenantRelated)
+            {
+                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
+            }
+
             sb.AppendLine($"foreach (var {elementName} in {parameterName})");
             sb.AppendLine("{");
 
@@ -206,8 +212,12 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("query.Clear();");
             sb.AppendLine("counter = 0;");
             sb.AppendLine("parameters.Clear();");
-            sb.AppendLine($"query.AppendFormat({queryName}, counter);");
-            sb.AppendLine("counter++;");
+
+            if (RepositoryInfo.IsTenantRelated)
+            {
+                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
+            }
+
             sb.AppendLine("}");
 
             foreach (var column in columns)
@@ -215,11 +225,9 @@ namespace WCFGenerator.RepositoriesGeneration.Core
                 sb.AppendLine($"parameters.Add($\"{column}{{counter}}\", {elementName}.{column});");
             }
 
-            if (RepositoryInfo.IsTenantRelated)
-            {
-                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
-            }
-            
+            sb.AppendLine($"query.AppendFormat({queryName}, counter);");
+            sb.AppendLine("counter++;");
+
             sb.AppendLine("}");
             sb.AppendLine($"{DataAccessServiceBaseRepositoryField}.Execute(query.ToString(), parameters);");
             sb.AppendLine("}");
@@ -235,6 +243,12 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("var query = new System.Text.StringBuilder();");
             sb.AppendLine("var counter = 0;");
             sb.AppendLine($"var parameters = new Dictionary<string, object>();");
+
+            if (RepositoryInfo.IsTenantRelated)
+            {
+                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
+            }
+
             sb.AppendLine($"foreach (var {elementName} in {parameterName})");
             sb.AppendLine("{");
 
@@ -244,16 +258,17 @@ namespace WCFGenerator.RepositoriesGeneration.Core
             sb.AppendLine("query.Clear();");
             sb.AppendLine("counter = 0;");
             sb.AppendLine("parameters.Clear();");
+
+            if (RepositoryInfo.IsTenantRelated)
+            {
+                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
+            }
+
             sb.AppendLine("}");
 
             foreach (var column in columns)
             {
                 sb.AppendLine($"parameters.Add($\"{column}{{counter}}\", {elementName}.{column});");
-            }
-
-            if (RepositoryInfo.IsTenantRelated)
-            {
-                sb.AppendLine($"parameters.Add($\"TenantId\", {DataAccessControllerBaseRepositoryField}.Tenant.TenantId);");
             }
 
             sb.AppendLine($"query.AppendFormat({queryName}, counter);");


### PR DESCRIPTION
parameters.Add($"TenantId", DataAccessController.Tenant.TenantId);

- эта строчка должна добавлять два раза, перед циклом и в if где обнуляем параметры запроса т.к. параметр TenantId должен добавляться один раз,


https://github.com/yumapos/YumaPos-Server-WCF/pull/3143